### PR TITLE
Cambio nombres de Métodos / Búsquedas Repositorio Contrato

### DIFF
--- a/src/main/java/GrupoF/Proyecto3/Repositorios/ClienteRepositorio.java
+++ b/src/main/java/GrupoF/Proyecto3/Repositorios/ClienteRepositorio.java
@@ -1,4 +1,3 @@
-
 package GrupoF.Proyecto3.Repositorios;
 
 import GrupoF.Proyecto3.Entidades.Cliente;
@@ -10,6 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ClienteRepositorio extends JpaRepository<Cliente, String> {
     @Query("SELECT c FROM Cliente c WHERE c.correo = :correo")
-    public Cliente findByCorreo(@Param("correo") String correo);
+    public Cliente buscarPorCorreo(@Param("correo") String correo);
 }
 

--- a/src/main/java/GrupoF/Proyecto3/Repositorios/ContratoRepositorio.java
+++ b/src/main/java/GrupoF/Proyecto3/Repositorios/ContratoRepositorio.java
@@ -2,10 +2,18 @@
 package GrupoF.Proyecto3.Repositorios;
 
 import GrupoF.Proyecto3.Entidades.Contrato;
+import GrupoF.Proyecto3.Entidades.Proveedor;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ContratoRepositorio extends JpaRepository<Contrato, String> {
     
+    @Query("SELECT c FROM Contrato c WHERE c.idCliente = :idCliente")
+    public Proveedor buscarPorIdCliente(@Param("idCliente") String idCliente);
+    
+    @Query("SELECT c FROM Contrato c WHERE c.idProveedor = :idProveedor")
+    public Proveedor buscarPorIdProveedor(@Param("idProveedor") String idProveedor);
 }

--- a/src/main/java/GrupoF/Proyecto3/Repositorios/ProveedorRepositorio.java
+++ b/src/main/java/GrupoF/Proyecto3/Repositorios/ProveedorRepositorio.java
@@ -1,6 +1,5 @@
 package GrupoF.Proyecto3.Repositorios;
 
-
 import GrupoF.Proyecto3.Entidades.Proveedor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,6 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProveedorRepositorio extends JpaRepository<Proveedor, String> {
     @Query("SELECT p FROM Proveedor p WHERE p.correo = :correo")
-    public Proveedor findByCorreo(@Param("correo") String correo);
+    public Proveedor buscarPorCorreo(@Param("correo") String correo);
 }
 


### PR DESCRIPTION
Se cambian los nombres de los metodos de findBy a buscarPor de acuerdo a lo solicitado.
Se adicionan las 2 querys solicitadas en el RepositorioContrato.
Por favor Dani tu ayuda con la revisión, a la espera de cualquier comentario.